### PR TITLE
Treat all 2xx HTTP status codes as success

### DIFF
--- a/src/atomic.js
+++ b/src/atomic.js
@@ -33,7 +33,7 @@
     request.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
     request.onreadystatechange = function () {
       if (request.readyState === 4) {
-        if (request.status === 200) {
+        if (request.status >= 200 && request.status < 300) {
           methods.success.apply(methods, parse(request));
         } else {
           methods.error.apply(methods, parse(request));


### PR DESCRIPTION
According to [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2), all status codes in the 200-299 range indicate

> [...] that the client's request was successfully received, understood, and accepted.
