### PR TITLE
Make module `require`able as an NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "http://github.com/toddmotto/atomic.git"
   },
+  "main": "./src/atomic.js",
   "homepage": "github.com/toddmotto/atomic",
   "version": "1.0.0",
   "devDependencies": {


### PR DESCRIPTION
Even though this is not registered in the NPM registry, this change allows one to:

``` sh
npm install git+https://github.com/toddmotto/atomic.git#v1.0.1 
```

And then, in your CommonJS environment,

``` js
var atomic = require( 'atomic' );

atomic. ...
```

(Assuming a new tag `v1.0.1` is published to GitHub.)

CC: https://github.com/toddmotto/atomic/issues/10
