### PR TITLE
[fix #77] prevent timeout errors from being processed in the .onreadystat…

### DIFF
--- a/src/js/atomic/atomic.js
+++ b/src/js/atomic/atomic.js
@@ -141,6 +141,9 @@
 				// Only run if the request is complete
 				if (request.readyState !== 4) return;
 
+				// #77 : prevent timeout errors from being processed here:
+				if (request.status == 0) return;
+
 				// Process the response
 				if (request.status >= 200 && request.status < 300) {
 					// If successful


### PR DESCRIPTION
…echange()

on a timeout, the onreadystatechange() will be processed before the .ontimeout() handler.  So we need to prevent the onreadystatechange() from responding to a timeout error (where response.state == 0).
