### PR TITLE
[fix] Prevent setting Content-Type header if the provided data is FormData

### DIFF
--- a/src/js/atomic/atomic.js
+++ b/src/js/atomic/atomic.js
@@ -79,6 +79,16 @@
 	};
 
 	/**
+	 * Check if the provided obj is a FormData object
+	 * @private
+	 * @param  {Object|Array|String} obj The object
+	 * @return {Bool}
+	 */
+	var isFormData = function(obj) {
+		return Object.prototype.toString.call(obj) === '[object FormData]';
+	};
+
+	/**
 	 * Parse text response into JSON
 	 * @private
 	 * @param  {String} req The response
@@ -96,10 +106,6 @@
 		}
 		return {data: result, xhr: req};
 	};
-
-	var isFormData = function(obj) {
-		return Object.prototype.toString.call(obj) === '[object FormData]';
-	}
 
 	/**
 	 * Convert an object into a query string

--- a/src/js/atomic/atomic.js
+++ b/src/js/atomic/atomic.js
@@ -97,6 +97,10 @@
 		return {data: result, xhr: req};
 	};
 
+	var isFormData = function(obj) {
+		return Object.prototype.toString.call(obj) === '[object FormData]';
+	}
+
 	/**
 	 * Convert an object into a query string
 	 * @link   https://blog.garstasio.com/you-dont-need-jquery/ajax/
@@ -106,7 +110,7 @@
 	var param = function (obj) {
 
 		// If already a string, or if a FormData object, return it as-is
-		if (typeof (obj) === 'string' || Object.prototype.toString.call(obj) === '[object FormData]') return obj;
+		if (typeof (obj) === 'string' || isFormData(obj)) return obj;
 
 		// If the content-type is set to JSON, stringify the JSON object
 		if (/application\/json/i.test(settings.headers['Content-type']) || Object.prototype.toString.call(obj) === '[object Array]') return JSON.stringify(obj);
@@ -213,6 +217,11 @@
 
 		// Merge options into defaults
 		settings = extend(defaults, options || {});
+
+		// clear Content-Type if provided data is FormData
+		if (isFormData(settings.data)) {
+			delete settings.headers['Content-type'];
+		}
 
 		// Make request
 		return makeRequest(url);

--- a/test/spec/atomic-spec.js
+++ b/test/spec/atomic-spec.js
@@ -95,6 +95,19 @@ describe('atomic', function () {
 					.toHaveBeenCalledWith('Content-type', 'application/json');
 		});
 
+		it('should not set Content-type when using FormData', function() {
+			atomic.ajax({
+				url: '/endpoint',
+				headers: {
+					'Content-type': 'application/json'
+				},
+				data: new FormData()
+			});
+
+			expect(XMLHttpRequest.prototype.setRequestHeader)
+					.not.toHaveBeenCalledWith('Content-type', 'application/json');
+		});
+
 	});
 
 });

--- a/test/spec/atomic-spec.js
+++ b/test/spec/atomic-spec.js
@@ -95,7 +95,7 @@ describe('atomic', function () {
 					.toHaveBeenCalledWith('Content-type', 'application/json');
 		});
 
-		it('should not set Content-type when using FormData', function() {
+		it('should not be set when using FormData', function() {
 			atomic.ajax({
 				url: '/endpoint',
 				headers: {


### PR DESCRIPTION
Completes issue #60 

Content-Type is no longer set if the provided data is `FormData`